### PR TITLE
Create component-reference.md

### DIFF
--- a/doc-templates/component-reference.md
+++ b/doc-templates/component-reference.md
@@ -1,0 +1,125 @@
+---
+linkTitle: Component Name
+title: \[Component Name] Component
+description: The [component name], which does [function], is provided by the [Gem name] in Open 3D Engine (O3DE). # Example
+weight: 200 # (Optional) Example
+toc: true
+---
+
+<!-- This is a template to create a component reference document. As you write this document, please refer to the writing guidelines: https://www.o3de.org/docs/contributing/to-docs/templates/component-reference-doc/-->
+
+<!-- Introduction - Describe the component and what it does. -->
+
+
+## Provider
+
+[Gem's name](/docs/user-guide/gems/reference/<path-to-gem-docs>)
+
+
+## Dependencies
+
+<!-- (Optional) List the component's dependencies -->
+
+
+## Use cases
+
+<!-- (Optional) Write the use cases in which a user may want to use this component. -->
+
+
+## Limitations
+
+<!-- (Optional) Write the limitations of this component. Don't include any "future work". -->
+
+
+## Properties
+
+<!-- This example is for a simple set of properties. 
+If you use this section, then delete the other Properties section. -->
+
+![[component name] interface](/images/<path-to-images>)
+
+| Property | Description | Value | default |
+| - | - | - | - |
+|   |   |   |   |
+|   |   |   |   |
+|   |   |   |   |
+
+
+## Properties
+
+<!-- This example is for a complex set of properties. 
+If you use this section, then delete the other Properties section. -->
+
+![[component name] interface](/images/<path-to-image>)
+
+
+### Base properties
+
+| Property | Description | Value | Default |
+| - | - | - | - |
+|   |   |   |   |
+|   |   |   |   |
+|   |   |   |   |
+
+### [Property group] properties
+
+![[property group] interface](/images/<path-to-image>)
+
+| Property | Description | Value | Default |
+| - | - | - | - |
+|   |   |   |   |
+|   |   |   |   |
+|   |   |   |   |
+
+### [Configuration] properties
+
+{{< tabs >}} 
+{{% tab name="[configuration 1] properties" %}}
+
+![[configuration 1] interface](/images/<path-to-image>)
+
+| Property | Description | Value | Default |
+| - | - | - | - |
+|   |   |   |   |
+|   |   |   |   |
+|   |   |   |   |
+
+{{% /tab %}}
+{{% tab name="[configuration 2] properties" %}}  
+
+![[configuration 2] interface](/images/<path-to-image>)
+
+| Property | Description | Value | Default |
+| - | - | - | - |
+|   |   |   |   |
+|   |   |   |   |
+|   |   |   |   |
+
+{{% /tab %}}
+{{< /tabs >}}
+
+
+## [Component feature]
+
+<!-- (Optional) Explain specific features of your component. Repeat this section for each additional topic, as needed. -->
+
+
+## [EBus interface name]RequestBus
+
+<!-- (Optional) Example: "Use the following request functions with the <Request EBus name> EBus interface to communicate with <component name> in your game." -->
+
+| Request Name | Description | Parameter | Return | Scriptable |
+| - | - | - | - | - |
+|   |   |   |   |   |
+|   |   |   |   |   |
+|   |   |   |   |   |
+
+## [EBus interface name]NotificationBus
+
+<!-- (Optional) Example: "Use the following notification functions with the <Notification EBus name> EBus interface to communicate with <component name> in your game." -->
+
+| Request Name | Description | Parameter | Return | Scriptable |
+| - | - | - | - | - |
+|   |   |   |   |   |
+|   |   |   |   |   |
+|   |   |   |   |   |

--- a/doc-templates/component-reference.md
+++ b/doc-templates/component-reference.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: Component Name
-title: \[Component Name] Component
+title: [Component Name] Component
 description: The [component name], which does [function], is provided by the [Gem name] in Open 3D Engine (O3DE). # Example
 weight: 200 # (Optional) Example
 toc: true
@@ -38,7 +38,7 @@ If you use this section, then delete the other Properties section. -->
 
 ![[component name] interface](/images/<path-to-images>)
 
-| Property | Description | Value | default |
+| Property | Description | Value | Default |
 | - | - | - | - |
 |   |   |   |   |
 |   |   |   |   |
@@ -108,7 +108,7 @@ If you use this section, then delete the other Properties section. -->
 
 <!-- (Optional) Example: "Use the following request functions with the <Request EBus name> EBus interface to communicate with <component name> in your game." -->
 
-| Request Name | Description | Parameter | Return | Scriptable |
+| Method Name | Description | Parameter | Return | Scriptable |
 | - | - | - | - | - |
 |   |   |   |   |   |
 |   |   |   |   |   |
@@ -118,7 +118,7 @@ If you use this section, then delete the other Properties section. -->
 
 <!-- (Optional) Example: "Use the following notification functions with the <Notification EBus name> EBus interface to communicate with <component name> in your game." -->
 
-| Request Name | Description | Parameter | Return | Scriptable |
+| Method Name | Description | Parameter | Return | Scriptable |
 | - | - | - | - | - |
 |   |   |   |   |   |
 |   |   |   |   |   |


### PR DESCRIPTION
This purpose of this PR is to move the component reference template from the website to the SIG Docs and Community repository. This PR is a fast-follow fix for the [PR #1415 in o3de.org](https://github.com/o3de/o3de.org/pull/1415)(merged) and depends on [PR #1472 in o3de.org](https://github.com/o3de/o3de.org/pull/1472)(open). 

As addressed by this [comment](https://github.com/o3de/o3de.org/pull/1415#discussion_r807384109) in PR #1415 in `o3de.org`. 

> @[sptramer](https://github.com/sptramer) sptramer [21 days ago](https://github.com/o3de/o3de.org/pull/1415#discussion_r807384109)
>
> Recommend removing this from the website and that we host a "templates" subsection for the SIG, where this can go and live. Will still do the review here, and we can accept this PR as-is and then make a fast-follow to post on the SIG repo and directly link to GitHub.


>@[chanmosq](https://github.com/chanmosq) chanmosq [20 days ago](https://github.com/o3de/o3de.org/pull/1415#discussion_r808503511)
>
> Sounds good to me. I'll leave as is and fast follow with a PR to remove the template from the website, add it to o3de/sig-docs-community, and update the links.