### PR TITLE
Add baseline tech reviewer requirements. [RELATED #61] 

### DIFF
--- a/governance/docs-tech-review-template.yaml
+++ b/governance/docs-tech-review-template.yaml
@@ -1,0 +1,46 @@
+name: 'SIG-<SIG-NAME>: Documentation Technical Reviewer Nomination'
+description: Nominate yourself or someone else to become a documentation reviewer on behalf of <SIG NAME> for technical accuracy.
+title: '<SIG-NAME> Documentation Technical Reviewer Nomination: <username>'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        In conjunction with sig-docs-community, each technical SIG has its own reviewer pool to ensure accurate documentation. This nomination form
+        is to become a _documentation technical reviewer_ on behalf of <SIG NAME>, responsible for reviewing documentation contributions to `o3de.org`
+        for technical correctness. Documentation technical reviewers are expected to:
+
+        * Assist in the review of `o3de.org` content for technical accuracy
+        * <Your SIG may add any additional specialized requirements for review.>
+        
+        **Maintaing status:** <Each SIG is required to set their own standards for maintaining status, depending on the size of their reviewer pool and feature velocity. Be aware that without technical reviewers, the Documentation and Community SIG cannot merge documentation under [RFC #61](https://github.com/o3de/sig-docs-community/issues/61) and [RFC #74](https://github.com/o3de/sig-docs-community/issues/74).>
+
+        For more on the general requirements of Reviewer roles, read our [Community Membership](https://github.com/o3de/community/blob/main/community-membership.md) information.
+  - type: input
+    id: username
+    attributes:
+      label: Nominee GitHub user name
+      placeholder: username
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Link to relevant pull requests or comments that demonstrate meeting the requirements.
+      placeholder: |
+        * <links to relevant pull requests or comments>
+        * ...
+    validations:
+      required: true
+  - type: textarea
+    id: information
+    attributes:
+      label: Support statement  (Optional)
+      description: If you'd like, include a brief statement about why you support this nomination.
+  - type: checkboxes
+    id: approvals
+    attributes:
+      label: '**BOXES TO BE CHECKED NOMINATION REVIEW**'
+      options:
+        - label: Is a Reviewer or Maintainer for <SIG NAME>.
+        - label: 1+ of <SIG NAME> Reviewers or Maintainers support the promotion.
+        - label: 1+ Reviewers or Maintainers of the Documentation and Community SIG support the promotion.

--- a/governance/docs-tech-review-template.yaml
+++ b/governance/docs-tech-review-template.yaml
@@ -18,14 +18,15 @@ body:
   - type: input
     id: username
     attributes:
-      label: Nominee GitHub user name
+      label: Nominee's GitHub username
       placeholder: username
     validations:
       required: true
   - type: textarea
     id: evidence
     attributes:
-      label: Link to relevant pull requests or comments that demonstrate meeting the requirements.
+      label: Relevant experience
+      description: Link to relevant pull requests or comments that demonstrate meeting the requirements.
       placeholder: |
         * <links to relevant pull requests or comments>
         * ...
@@ -39,7 +40,8 @@ body:
   - type: checkboxes
     id: approvals
     attributes:
-      label: '**BOXES TO BE CHECKED NOMINATION REVIEW**'
+      label: Nomination Review Checklist
+      description: Leave this empty. This checklist will be filled in by a sig-docs-community member who is reviewing the nomination.
       options:
         - label: Is a Reviewer or Maintainer for <SIG NAME>.
         - label: 1+ of <SIG NAME> Reviewers or Maintainers support the promotion.

--- a/governance/reviewers-maintainers.md
+++ b/governance/reviewers-maintainers.md
@@ -12,7 +12,7 @@ reviewer pools to take on additional responsibility, and serve as trusted source
 
 The Documentation and Community SIG also maintains a technical reviewer pool for the `o3de.org` website and its related infrastructure.
 
-The technical SIGs also maintain reviewer pools for becoming a technical reviewer. 
+The technical SIGs also maintain reviewer pools for becoming a technical reviewer. There is a standard [baseline requirement](./docs-tech-review-template.yaml) for becoming a technical reviewer for any SIG. Serving as a docs technical reviewer is at the discretion of the associated SIG, and they may change qualifications for being a reviewer at any time.
 
 ### Open 3D Engine Community Roles
 


### PR DESCRIPTION
Add basic tech reviewer requirements for becoming a documentation technical reviewer. Requires feedback from a majority of technical SIGs for acceptance.